### PR TITLE
feat(Disk Widget): Display disk temperature instead of usage in Mini …

### DIFF
--- a/Modules/Disk/main.swift
+++ b/Modules/Disk/main.swift
@@ -262,7 +262,13 @@ public class Disk: Module {
         
         self.menuBar.widgets.filter{ $0.isActive }.forEach { (w: SWidget) in
             switch w.item {
-            case let widget as Mini: widget.setValue(d.percentage)
+            case let widget as Mini:
+                let temperatureC = Double(d.smart?.temperature ?? 0).rounded(.up)
+                let temperatureVal = Measurement(value: temperatureC, unit: UnitTemperature.celsius)
+                    .converted(to: UnitTemperature.current)
+                    .value.rounded(.up)/100
+                widget.setValue(temperatureVal)
+                widget.setSuffix(UnitTemperature.current.symbol)
             case let widget as BarChart: widget.setValue([[ColorValue(d.percentage)]])
             case let widget as MemoryWidget:
                 widget.setValue((DiskSize(d.free).getReadableMemory(), DiskSize(d.size - d.free).getReadableMemory()), usedPercentage: d.percentage)


### PR DESCRIPTION
# Summary

This MR introduces a modification to the Disk widget in the menu bar, replacing the previously displayed disk usage percentage with the disk temperature.

# Context & Motivation

I wanted to display disk temperature directly in the menu bar, as discussed in  [Issue #2225](https://github.com/exelban/stats/issues/2225)
After reviewing various issues, I realized that the sensor widget does not support displaying disk temperature, which led me to explore an alternative approach. I decided to integrate this feature within the Disk widget instead.

As a newcomer to Swift, I took this opportunity to install Xcode and experiment with a simple implementation.

# Implementation Details
- Extracts the disk temperature from S.M.A.R.T. data, rounding it up.
- Converts the temperature to the system’s current unit preference before displaying it.
- Updates the Mini widget to show temperature instead of disk usage.

> After applying this modification, the Mini widget now displays the disk temperature instead:
![image](https://github.com/user-attachments/assets/64592fa1-f871-4920-8835-c86d260df344)

# Notes

This is an intrusive modification, as disk usage is no longer displayed in the Mini widget. However, since disk space is not my primary concern, this change currently meets my personal needs.
I hope this feature can eventually be upstreamed in the future, possibly as a configurable option.